### PR TITLE
Add HF Jobs smoke test workflow

### DIFF
--- a/.github/workflows/hf-jobs-smoke-test.yml
+++ b/.github/workflows/hf-jobs-smoke-test.yml
@@ -1,0 +1,16 @@
+name: HF Jobs Smoke Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: hf-jobs-cpu-upgrade
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Confirm HF Jobs runner
+        run: |
+          echo "Hello from Hugging Face Jobs"
+          uname -a


### PR DESCRIPTION
## Summary
- Add a minimal GitHub Actions smoke-test workflow that targets the HF Jobs runner label `hf-jobs-cpu-upgrade`.
- Include a manual trigger so the HF Jobs integration can be re-tested on demand.

## Test plan
- Verify the workflow runs on Hugging Face Jobs after this PR opens.